### PR TITLE
check if author is a *Hash* instead of an *Object* 

### DIFF
--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -43,7 +43,7 @@ module Middleman
               opts[:article][:modified_time] = Time.parse(current_article.data.modified_time).utc.iso8601
             end
             if current_article.data.author
-              if current_article.data.author.kind_of?(Object)
+              if current_article.data.author.kind_of?(Hash)
                 opts[:article][:author] = {}
                 [:first_name, :last_name, :username, :gender].each do | field |
                   if current_article.data.author[field]


### PR DESCRIPTION
Currently when the `author` tag is a string (containing first name <space> last name for example), this leads to an error. 

My initial intention with this line was to check if the variable is a Hash, but my limited ruby knowledge lead me to check if it was an `Object`. Now it returns `true` for `String` objects as well, which is wrong. This PR should fix that.