### PR TITLE
Fix unknown value error by type checking that is too strict

### DIFF
--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -135,7 +135,7 @@ module Middleman
         else
           if obj.respond_to?(:value)
             value = obj.value
-            if value.is_a?(Middleman::Util::EnhancedHash)
+            if value.is_a?(Hash)
               value.map{|k,v|
                 og_tag(k.to_s.empty? ? key.dup : (key.dup << k.to_s) , v, prefix, &block)
               }.join("\n")


### PR DESCRIPTION
In my envrionment,  the `value` in file diff tend to be `Hashie::Mash` object. 
And go into `else` branch and `raise 'Unknown value'`.

BTW,  there is a class inheritance

```ruby 
class Middleman::Util::EnhancedHash < ::Hashie::Mash; end
class Hashie::Mash < Hash; end
```

So, we don't need to check too detailed type like `Middleman::Util::EnhancedHash`, but we should check `value` has  `Hash` interface or not.