### PR TITLE
Deal with attributes in Time format, fallback to String format.

### DIFF
--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -37,10 +37,20 @@ module Middleman
               opts[:article][:section] = current_article.data.section
             end
             if current_article.data.expiration_time
-              opts[:article][:expiration_time] = Time.parse(current_article.data.expiration_time).utc.iso8601
+              if current_article.data.expiration_time.is_a? Time
+                expiration_time = current_article.data.expiration_time
+              else
+                expiration_time = Time.parse(current_article.data.expiration_time.to_s)
+              end
+              opts[:article][:expiration_time] = expiration_time.utc.iso8601
             end
             if current_article.data.modified_time
-              opts[:article][:modified_time] = Time.parse(current_article.data.modified_time).utc.iso8601
+              if current_article.data.modified_time.is_a? Time
+                modified_time = current_article.data.modified_time
+              else
+                modified_time = Time.parse(current_article.data.modified_time.to_s)
+              end
+              opts[:article][:modified_time] = modified_time.utc.iso8601
             end
             if current_article.data.author
               if current_article.data.author.kind_of?(Object)


### PR DESCRIPTION
I'm not sure why but I suspect middleman parses strings that look like time before passing it to plugins, perhaps only in recent versions. In any case, I added a type check, if the value is an instance of `Time`, parsing is skipped because Time doesn't have `.to_s` and parsing is not even necessary. If it does happen to be `String`, (perhaps with older versions of middleman?) the `String` is parsed to `Time` as it used to.