### PR TITLE
Allow mutliple authors for articles

### DIFF
--- a/features/blog.feature
+++ b/features/blog.feature
@@ -25,4 +25,19 @@ Feature: Middleman Blog support
     Then I should see '<meta content="http://myblog.foo.tld/2014/04/12/my-test.html" property="og:url" />'
     Then I should see '<meta content="Fixture page" property="og:title" />'
 
+Scenario: multi author article page
+    Given the Server is running at "test-blog"
+    When I go to "2019/07/18/multi-author-test.html"
+    Then I should see '<meta content="article" property="og:type" />'
+    Then I should see '<meta content="Maria" property="article:author:first_name" />'
+    Then I should see '<meta content="Eaton" property="article:author:last_name" />'
+    Then I should see '<meta content="meaton" property="article:author:username" />'
+    Then I should see '<meta content="female" property="article:author:gender" />'
+    Then I should see '<meta content="Shawn" property="article:author:first_name" />'
+    Then I should see '<meta content="justshawn" property="article:author:username" />'
+    Then I should see '<meta content="male" property="article:author:gender" />'
+    Then I should see '<meta content="http://myblog.foo.tld/2019/07/18/multi-author-test.html" property="og:url" />'
+    Then I should see '<meta content="Multi author fixture page" property="og:title" />'
+
+
 

--- a/fixtures/test-blog/source/2019-07-18-multi-author-test.html.slim
+++ b/fixtures/test-blog/source/2019-07-18-multi-author-test.html.slim
@@ -1,0 +1,16 @@
+---
+title: Multi author fixture page
+date: 2019-07-18 16:45
+authors:
+- first_name: Maria
+  last_name: Eaton
+  username: meaton
+  gender: female
+- first_name: Shawn
+  username: justshawn
+  gender: male
+---
+
+h1 Hello multi author article
+
+p This is a multi author article

--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -42,13 +42,12 @@ module Middleman
             if current_article.data.modified_time
               opts[:article][:modified_time] = Time.parse(current_article.data.modified_time).utc.iso8601
             end
-            if current_article.data.author
-              if current_article.data.author.kind_of?(Object)
-                opts[:article][:author] = {}
-                [:first_name, :last_name, :username, :gender].each do | field |
-                  if current_article.data.author[field]
-                    opts[:article][:author][field] = current_article.data.author[field]
-                  end
+            if current_article.data.author || current_article.data.authors
+              authors = current_article.data.authors || [current_article.data.author]
+              opts[:article][:author] = []
+              authors.each do |author|
+                if author.is_a? Hash
+                  opts[:article][:author] << author.slice(:first_name, :last_name, :username, :gender)
                 end
               end
             end


### PR DESCRIPTION
The OpenGraph specification allows the use of arrays of some attributes, among them: `article:author`. Attributes are to be compounded by the interpreter. As long as there is no repeat in sub attributes (`:first_name`, `:last_name`, `:nickname`, `:gender`) they are to be considered attributes of the same author. These changes just iterate over the content of the authors list and add them all whether 1 or more.

Note that I found a bug a few lines above, after merging this fork the plugin will thus still be broken, so better merge #11 before this one. 

Also this superseeds:  #9, which can be closed 