### PR TITLE
Add support for I18n

### DIFF
--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -85,6 +85,9 @@ module Middleman
               opts[:og][:description] = yield_content(:description)
             end
           end
+          if Middleman::OGP::Helper.auto.include?('locale') && I18n.locale
+            opts[:og][:locale] = I18n.locale
+          end
           if Middleman::OGP::Helper.auto.include?('url') &&
              Middleman::OGP::Helper.base_url
             opts[:og][:url] = URI.join(Middleman::OGP::Helper.base_url, current_resource.url)


### PR DESCRIPTION
If a locale is set with I18n and included in the "auto" fields, override it in the `og` data.

Usage: add this to your `config.rb`

```ruby
activate :i18n  # You might want to configure more than just this

# Activate OGP plugin. Note that this does not have i18n support, so that is
# added manually in main.slim
activate :ogp do |ogp|
  ogp.auto = ['title', 'description', 'locale', 'url']
end
```