### PR TITLE
Allow overriding variables in all ogp namespaces

### DIFF
--- a/lib/middleman-ogp/extension.rb
+++ b/lib/middleman-ogp/extension.rb
@@ -70,24 +70,26 @@ module Middleman
               end
             end
           end
-          opts[:og] ||= {}
-          if Middleman::OGP::Helper.auto.include?('title')
-            if current_resource.data['title']
-              opts[:og][:title] = current_resource.data['title']
-            elsif content_for?(:title)
-              opts[:og][:title] = yield_content(:title)
+          for namespace in Middleman::OGP::Helper.namespaces.keys
+            opts[namespace] ||= {}
+            if Middleman::OGP::Helper.auto.include?('title')
+              if current_resource.data['title']
+                opts[namespace][:title] = current_resource.data['title']
+              elsif content_for?(:title)
+                opts[namespace][:title] = yield_content(:title)
+              end
             end
-          end
-          if Middleman::OGP::Helper.auto.include?('description')
-            if current_resource.data['description']
-              opts[:og][:description] = current_resource.data['description']
-            elsif content_for?(:description)
-              opts[:og][:description] = yield_content(:description)
+            if Middleman::OGP::Helper.auto.include?('description')
+              if current_resource.data['description']
+                opts[namespace][:description] = current_resource.data['description']
+              elsif content_for?(:description)
+                opts[namespace][:description] = yield_content(:description)
+              end
             end
-          end
-          if Middleman::OGP::Helper.auto.include?('url') &&
-             Middleman::OGP::Helper.base_url
-            opts[:og][:url] = URI.join(Middleman::OGP::Helper.base_url, current_resource.url)
+            if Middleman::OGP::Helper.auto.include?('url') &&
+               Middleman::OGP::Helper.base_url
+              opts[namespace][:url] = URI.join(Middleman::OGP::Helper.base_url, current_resource.url)
+            end
           end
 
           Middleman::OGP::Helper.ogp_tags(opts) do |name, value|


### PR DESCRIPTION
Under  normal circumstances, if you use several namespaces, `middleman-ogp` will only allow you to override variables in the `og` namspace by defining them as page variables. Take this `index.md` as an example:

```markdown
title: My Index Page
description: My index page looks great!
---
# Welcome

I'm one of those people that writes welcome on their home page.
```
And let's assume this is our `config.rb`:

```ruby
activate :ogp do |ogp|
  ogp.namespaces = {
    og: data.ogp.og,
    twitter: data.ogp.twitter
  }
end

```

The `og` tags for this page would look something like:

```html
    <meta property="og:title" content="My Index Page" />
    <meta property="og:description" content="My index page looks great!" />
    <meta property="twitter:description" content="whatever description I have in data/ogp/twitter.yml" />
    <meta property="twitter:title" content="whatever title I have in data/ogp/twitter.yml" />
```

I want the  Twitter description and title to be my overridden variable as well. This PR makes that possible.